### PR TITLE
Hide nonessential items in printouts

### DIFF
--- a/lms/static/sass/_overrides.scss
+++ b/lms/static/sass/_overrides.scss
@@ -24,3 +24,22 @@
     box-shadow: .5em .5em .5em black;
   }
 }
+
+// Hide nonessential items in printouts
+@media print {
+    nav,
+    button,
+    footer,
+    .sequence-nav,
+    .course-index,
+    .instructor-info-action {
+	display: none !important;
+    }
+
+    header,
+    .course-content,
+    .course-index,
+    .course-wrapper {
+	border: none !important;
+    }
+}


### PR DESCRIPTION
The default style sheets don't do a nearly comprehensive job at
suppressing everything that makes sense to from printed output.

Thus, use a @media print section in the _overrides.scss partial to:

- Hide nav, footer, and button elements,
- Hide the course index,
- Hide the "sequence" navigation ("Previous" and "Next" buttons),
- Hide the staff actions ("View in Studio", etc.),
- Suppress borders.

Fixes hastexo/edx-comprehensive-theme#10.