### PR TITLE
WIP: Make lab instructions better suited for printing

### DIFF
--- a/lms/static/sass/_overrides.scss
+++ b/lms/static/sass/_overrides.scss
@@ -13,20 +13,23 @@
   display: none;
 }
 
-// The HTML xmodule
-.xblock-student_view-html {
-  // Center all images
-  img {
-    display: block;
-    margin: 0 auto;
-  }
+// Format lab instructions for on-screen output
+@media screen {
+  // The HTML xmodule
+  .xblock-student_view-html {
+    // Center all images
+    img {
+      display: block;
+      margin: 0 auto;
+    }
 
-  // hastexo XBlock theme
-  .lab_instructions {
-    height: 20em;
-    overflow-y: auto;
-    margin-bottom: 1em;
-    box-shadow: .5em .5em .5em black;
+    // hastexo XBlock theme
+    .lab_instructions {
+      height: 20em;
+      overflow-y: auto;
+      margin-bottom: 1em;
+      box-shadow: .5em .5em .5em black;
+    }
   }
 }
 
@@ -37,7 +40,8 @@
     footer,
     .sequence-nav,
     .course-index,
-    .instructor-info-action {
+    .instructor-info-action,
+    #terminal {
 	display: none !important;
     }
 


### PR DESCRIPTION
If a learner wants to print out lab instructions, or save them to a PDF, then it really doesn't make sense to restrict their height. Also, it doesn't really help if we print out the contents of the Guacamole terminal.

Thus, restrict the height limitation to `@media screen`, and suppress the terminal window's display with `@media print`.